### PR TITLE
Add "tail" webpage for stopped apps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ sign-commit = true
 
 [dependencies]
 futures = "0.3.1"
-tokio = { version = "0.2.4", features = ["tcp", "signal", "fs", "time", "uds", "io-util"] }
+tokio = { version = "0.2.4", features = ["tcp", "signal", "fs", "time", "uds", "io-util", "sync"] }
 hyper = "0.13.0"
 url = "2.0.0"
 toml = "0.5"

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,5 @@
+use futures::Stream;
+
 use crate::config;
 use crate::process::Process;
 
@@ -82,5 +84,15 @@ impl App {
 
     pub fn tld(&self) -> &str {
         &self.tld
+    }
+
+    pub fn output_stream(&self) -> impl Stream<Item = (Process, String)> {
+        eprintln!("Registering output listener");
+
+        futures::stream::select_all(
+            self.processes
+                .iter()
+                .map(|process| process.register_output_watcher()),
+        )
     }
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -27,7 +27,10 @@ impl Output {
     {
         while let Some(line) = stream.next_line().await.transpose() {
             match line {
-                Ok(line) => println!("{}: {}", pick_color(1).paint(&self.name), line),
+                Ok(line) => {
+                    println!("{}: {}", pick_color(1).paint(&self.name), line);
+                    self.process.output_line(line);
+                }
                 Err(error) => eprintln!("Error in log output: {}", error),
             }
         }

--- a/src/proxy/autostart_response.rs
+++ b/src/proxy/autostart_response.rs
@@ -1,39 +1,15 @@
 use hyper::{Body, Response};
 
-const RESTART_RESPONSE: &str = "
-<!doctype html>
-<html>
-    <head>
-        <title>App not running, trying to start it | Oxidux</title>
-        <style>
-            h1 {
-                font-size: 1.5em;
-            }
-        </style>
-    </head>
-    <body>
-        <h1>App doesn't seem to be running, trying to start it now.</h1>
-        <p>Refreshing in <span id='time'>5</span> seconds</p>
-
-        <script>
-            var timeEl = document.getElementById('time');
-            var seconds = parseInt(timeEl.textContent);
-
-            var intervalId = setInterval(function() {
-                seconds -= 1;
-                timeEl.innerText = seconds;
-
-                if (seconds < 1) {
-                    location.reload();
-                    clearInterval(intervalId);
-                }
-            }, 1000);
-        </script>
-    </body>
-</html>
-";
+const RESTART_RESPONSE: &str = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/static/restart_response.html"
+));
 
 pub fn autostart_response() -> Response<Body> {
     let body = Body::from(RESTART_RESPONSE);
-    Response::new(body)
+
+    Response::builder()
+        .header("Content-Type", "text/html; charset=utf-8")
+        .body(body)
+        .unwrap()
 }

--- a/src/proxy/meta_server.rs
+++ b/src/proxy/meta_server.rs
@@ -1,0 +1,49 @@
+use futures::StreamExt;
+use hyper::{Body, Request, Response, StatusCode};
+
+use crate::app::App;
+
+pub fn handle_request(request: Request<Body>, app: App) -> Response<Body> {
+    let action = request.uri().path().split('/').nth(2);
+
+    match action {
+        Some("status") => status_response(app),
+        Some("logstream") => logstream_response(app),
+        _ => not_found_response(),
+    }
+}
+
+pub fn is_meta_request<T>(request: &Request<T>) -> bool {
+    request.uri().path().starts_with("/__oxidux__/")
+}
+
+fn status_response(app: App) -> Response<Body> {
+    let status = if app.is_running() {
+        "Running"
+    } else {
+        "Stopped"
+    };
+
+    Response::new(Body::from(status))
+}
+
+fn not_found_response() -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::from("Not Found"))
+        .unwrap()
+}
+
+fn logstream_response(app: App) -> Response<Body> {
+    let output = app
+        .output_stream()
+        .map(|(process, line)| -> Result<_, failure::Error> {
+            Ok(format!("data: {}: {}\n\n", process.name(), line))
+        });
+
+    Response::builder()
+        .header("Content-Type", "text/event-stream")
+        .header("Cache-Control", "no-cache")
+        .body(Body::wrap_stream(output))
+        .unwrap()
+}

--- a/static/restart_response.html
+++ b/static/restart_response.html
@@ -1,0 +1,46 @@
+<!doctype html>
+<html>
+    <head>
+        <title>App not running, trying to start it | Oxidux</title>
+        <style>
+            body {
+                display: flex;
+                flex-direction: column;
+                height: 90vh;
+            }
+
+            h1 {
+                font-size: 1.5em;
+            }
+
+            pre {
+                font-family: monospace;
+                overflow: auto;
+
+                /* Solarized dark colorscheme */
+                color: #eee8d5;
+                background: #002b36;
+            }
+        </style>
+    </head>
+    <body>
+        <h1>App doesn't seem to be running, trying to start it now.</h1>
+
+        <button onclick="location.reload()">Retry request</button>
+
+        <pre id="log"></pre>
+
+        <script>
+            const stream = new EventSource('/__oxidux__/logstream')
+
+            pre = document.getElementById('log')
+            stream.onmessage = ({data}) => {
+                pre.innerText += data
+                pre.innerText += "\n"
+
+                // Scroll to bottom
+                pre.scrollTop = pre.scrollHeight
+            }
+        </script>
+    </body>
+</html>


### PR DESCRIPTION
Wire up EventSource endpoint that streams log messages for a given app.
This ensures that when apps fail to start you are presented with useful
info as to why.

Fixes #15 