### PR TITLE
Refactor process state

### DIFF
--- a/src/process.rs
+++ b/src/process.rs
@@ -28,6 +28,20 @@ pub struct Process {
 
 const LOCK_TIMEOUT_SECS: u64 = 2;
 
+#[derive(Debug, Clone)]
+pub(crate) enum RunState {
+    /// Process is not running - initial state
+    Stopped,
+    /// Start request received, but PID not yet set
+    Starting,
+    /// Process is running with a known PID
+    Running(Pid),
+    /// Killing process, but haven't yet confirmed
+    Terminating(Pid),
+    /// Same as `Terminating`, but with the intention to restart
+    Restarting(Pid),
+}
+
 #[derive(Debug)]
 struct Inner {
     app_name: String,
@@ -35,8 +49,7 @@ struct Inner {
     port: u16,
     command: String,
     directory: String,
-    pid: Option<Pid>,
-    restart_pending: bool,
+    state: RunState,
     output_channel: broadcast::Sender<(Process, String)>,
 }
 
@@ -54,8 +67,7 @@ impl Process {
             port,
             command,
             directory: expand_path(&app_config.directory),
-            pid: None,
-            restart_pending: false,
+            state: RunState::Stopped,
             output_channel,
         };
 
@@ -140,14 +152,18 @@ impl Process {
     }
 
     pub async fn start(&self) -> Result<(), String> {
-        self.set_restart_pending(false).await;
+        if !matches!(self.run_state().await, RunState::Stopped) {
+            return Err("Ignoring start request - process is not stopped".to_string());
+        }
+
+        self.set_run_state(RunState::Starting).await;
 
         if self.respawn_tmux_session().await.is_ok() {
-            println!("Respawned existing session");
+            eprintln!("Respawned existing session");
             // Bail out if respawning worked
             return Ok(());
         }
-        println!("Starting new session");
+        eprintln!("Starting new session");
 
         // Clean up any existing tmux sessions with conflicting names
         self.kill_tmux_session().await?;
@@ -211,54 +227,54 @@ impl Process {
 
     pub async fn restart(&self) {
         eprintln!("restarting");
-        self.stop().await;
 
-        self.set_restart_pending(true).await;
-
-        if !self.is_running().await {
-            self.start().await.unwrap_or_else(|e| eprintln!("{}", e));
+        match self.run_state().await {
+            RunState::Restarting(_) | RunState::Starting => {
+                eprintln!("Ignoring restart request, process is in invalid state");
+            }
+            RunState::Stopped => self.start().await.unwrap_or_else(|e| eprintln!("{}", e)),
+            RunState::Running(pid) | RunState::Terminating(pid) => {
+                self.set_run_state(RunState::Restarting(pid)).await;
+                signal_pid(pid, Signal::SIGINT).unwrap_or_else(|e| eprintln!("{}", e));
+            }
         }
     }
 
     pub async fn process_died(&self) {
-        self.set_stopped().await;
+        let previous_state = self.run_state().await;
+        self.set_run_state(RunState::Stopped).await;
 
-        if self.restart_pending().await {
+        if let RunState::Restarting(_) = previous_state {
             self.start().await.unwrap_or_else(|e| eprintln!("{}", e));
         }
     }
 
     pub async fn stop(&self) {
-        eprintln!("Stopping process {}", self.name().await);
-
-        match self.send_signal(Signal::SIGINT).await {
-            Ok(_) => {
-                eprintln!("Successfully sent stop signal");
+        match self.run_state().await {
+            RunState::Starting | RunState::Stopped => {
+                eprintln!("Ignoring stop request, process is in invalid state");
             }
-            Err(msg) => eprintln!("Couldn't SIGINT, got err {}", msg),
+            RunState::Running(pid) | RunState::Terminating(pid) | RunState::Restarting(pid) => {
+                self.set_run_state(RunState::Terminating(pid)).await;
+                signal_pid(pid, Signal::SIGINT).unwrap_or_else(|e| eprintln!("{}", e));
+            }
         }
     }
 
     pub async fn is_running(&self) -> bool {
-        self.pid().await.is_some()
+        if let RunState::Running(_) = self.run_state().await {
+            true
+        } else {
+            false
+        }
     }
 
-    async fn restart_pending(&self) -> bool {
-        self.inner().await.restart_pending
+    pub(crate) async fn run_state(&self) -> RunState {
+        self.inner().await.state.clone()
     }
 
-    async fn set_restart_pending(&self, state: bool) {
-        let mut inner = self.inner_mut().await;
-        inner.restart_pending = state
-    }
-
-    async fn send_signal(&self, signal: Signal) -> Result<(), &str> {
-        let pid = self.pid().await.ok_or("Pid is empty")?;
-
-        let group_pid = unistd::getpgid(Some(pid)).map_err(|_| "Couldn't find group for PID")?;
-
-        eprintln!("Sending {:?} to process group {}", signal, group_pid);
-        signal::kill(negate_pid(group_pid), signal).map_err(|_| "Failed to signal pid")
+    async fn set_run_state(&self, new_state: RunState) {
+        self.inner_mut().await.state = new_state;
     }
 
     async fn shell_args(&self) -> [String; 5] {
@@ -290,21 +306,20 @@ impl Process {
         self.inner().await.command.clone()
     }
 
-    pub async fn pid(&self) -> Option<Pid> {
-        self.inner().await.pid
+    async fn pid(&self) -> Option<Pid> {
+        match self.run_state().await {
+            RunState::Running(pid) | RunState::Restarting(pid) | RunState::Terminating(pid) => {
+                Some(pid)
+            }
+            _ => None,
+        }
     }
 
     async fn set_pid(&self, pid: u32) {
         eprintln!("Setting pid for {} to {}", self.name().await, pid);
         let pid = Pid::from_raw(pid as i32);
 
-        let mut inner = self.inner_mut().await;
-        inner.pid = Some(pid);
-    }
-
-    async fn set_stopped(&self) {
-        let mut inner = self.inner_mut().await;
-        inner.pid = None;
+        self.set_run_state(RunState::Running(pid)).await
     }
 
     fn watch_for_exit(&self) {
@@ -367,6 +382,13 @@ impl Process {
 }
 
 const WATCH_INTERVAL_MS: u64 = 100;
+
+fn signal_pid(pid: Pid, signal: Signal) -> Result<(), &'static str> {
+    let group_pid = unistd::getpgid(Some(pid)).map_err(|_| "Couldn't find group for PID")?;
+
+    eprintln!("Sending {:?} to process group {}", signal, group_pid);
+    signal::kill(negate_pid(group_pid), signal).map_err(|_| "Failed to signal pid")
+}
 
 fn negate_pid(pid: Pid) -> Pid {
     let pid_id: i32 = pid.into();

--- a/src/proxy.rs
+++ b/src/proxy.rs
@@ -90,7 +90,7 @@ async fn handle_request(
 
     let app = {
         match host_resolver::resolve(&host).await {
-            Some(app) => app.clone(),
+            Some(app) => app,
             None => {
                 let process_manager = ProcessManager::global_read().await;
                 return Ok(host_missing::missing_host_response(host, &process_manager).await);
@@ -127,14 +127,14 @@ fn build_address(config: &Config) -> SocketAddr {
     format!("127.0.0.1:{}", port).parse().unwrap()
 }
 
-fn app_url(process: &App, request_url: &Uri) -> Uri {
+fn app_url(app: &App, request_url: &Uri) -> Uri {
     let base_url = Url::parse("http://localhost/").unwrap();
 
     let mut destination_url = base_url
         .join(request_url.path_and_query().unwrap().as_str())
         .expect("Invalid request URL");
 
-    destination_url.set_port(Some(process.port())).unwrap();
+    destination_url.set_port(Some(app.port())).unwrap();
 
     eprintln!("Starting request to backend {}", destination_url);
 

--- a/src/proxy/meta_server.rs
+++ b/src/proxy/meta_server.rs
@@ -25,13 +25,9 @@ async fn status_response(app: App) -> color_eyre::Result<Response<Body>> {
 
     for process in app.processes {
         status.push_str(&format!(
-            "{}: {}\n",
+            "{}: {:?}\n",
             process.name().await,
-            process
-                .pid()
-                .await
-                .map(|p| p.to_string())
-                .unwrap_or_else(|| "Stopped".to_string())
+            process.run_state().await
         ));
     }
 


### PR DESCRIPTION
Use an enum to represent process state and add a force kill for processes that fail to shutdown.