### PR TITLE
Address clippy warnings

### DIFF
--- a/src/ipc_command.rs
+++ b/src/ipc_command.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use crate::config;
 
 #[derive(Serialize, Deserialize, Debug)]
-pub(crate) enum IPCCommand {
+pub(crate) enum IpcCommand {
     Restart {
         process_name: Option<String>,
         directory: String,
@@ -21,7 +21,7 @@ pub(crate) enum IPCCommand {
     Ping,
 }
 
-impl IPCCommand {
+impl IpcCommand {
     pub fn restart_command(process_name: Option<String>, directory: String) -> Self {
         Self::Restart {
             process_name,
@@ -56,7 +56,7 @@ pub fn ping_server() -> color_eyre::Result<String> {
     socket.set_read_timeout(timeout)?;
     socket.set_write_timeout(timeout)?;
 
-    let command = IPCCommand::heartbeat_command();
+    let command = IpcCommand::heartbeat_command();
     serde_json::to_writer(&socket, &command)?;
     socket.write_all(b"\n")?;
     socket.flush()?;

--- a/src/ipc_response.rs
+++ b/src/ipc_response.rs
@@ -4,7 +4,7 @@ use crate::process::Process;
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug)]
-pub enum IPCResponse {
+pub enum IpcResponse {
     NotFound(String),
     ConnectionDetails {
         app_name: String,
@@ -14,16 +14,19 @@ pub enum IPCResponse {
     Status(String),
 }
 
-impl IPCResponse {
+impl IpcResponse {
     pub async fn for_process(process: &color_eyre::Result<Process>) -> Self {
         match process {
-            Ok(process) => IPCResponse::ConnectionDetails {
-                app_name: process.app_name().await,
-                tmux_socket: config::tmux_socket(),
-                tmux_session: process.tmux_session().await,
-            },
+            Ok(process) => {
+                let app_name = process.app_name().await;
+                IpcResponse::ConnectionDetails {
+                    app_name,
+                    tmux_socket: config::tmux_socket(),
+                    tmux_session: process.tmux_session().await,
+                }
+            }
 
-            Err(error) => IPCResponse::NotFound(error.to_string()),
+            Err(error) => IpcResponse::NotFound(error.to_string()),
         }
     }
 }

--- a/src/process.rs
+++ b/src/process.rs
@@ -281,11 +281,7 @@ impl Process {
     }
 
     pub async fn is_running(&self) -> bool {
-        if let RunState::Running(_) = self.run_state().await {
-            true
-        } else {
-            false
-        }
+        matches!(self.run_state().await, RunState::Running(_))
     }
 
     pub(crate) async fn run_state(&self) -> RunState {


### PR DESCRIPTION
Clippy added some lints that conflict with existing code. The one about
not having two awaits in a struct initializer is apparently a bug, but
I'm moving it to a temp var to silence the warning.